### PR TITLE
Fixing replay mode compatibility by adding telemetry stream state detection

### DIFF
--- a/gt7communication.py
+++ b/gt7communication.py
@@ -211,8 +211,8 @@ class GT7Communication(Thread):
             time_delta = data_history[index].recvtime - data_history[index + 1].recvtime
             abs_rpm_delta = abs(data_history[index].rpm - data_history[index + 1].rpm)
             abs_speed_delta = abs(data_history[index].car_speed - data_history[index + 1].car_speed)
-            if time_delta <= 1.0 / 30 and (abs_rpm_delta > 1000 or abs_speed_delta > 30):
-                log.info('time delta: ' + str(time_delta) + '; rpm delta: ' + str(abs_rpm_delta) + '; speed_delta: ' + str(abs_speed_delta))
+            if time_delta <= 1.0 / 30 and (abs_rpm_delta > data_history[index + 1].rpm_rev_limiter * 0.1 or abs_speed_delta > data_history[index + 1].estimated_top_speed * 0.1):
+                log.info('Replay exit detected: time delta: %.4f s; rpm delta: %.2f (%.2f%%); speed delta: %.2f kph(%.2f%%)', time_delta, abs_rpm_delta, abs_rpm_delta * 100 / data_history[index + 1].rpm_rev_limiter, abs_speed_delta, abs_speed_delta * 100 / data_history[index + 1].estimated_top_speed)
                 for index_ in range (index + 1, len(data_history)):
                     data_history.pop()
                 return True

--- a/gt7communication.py
+++ b/gt7communication.py
@@ -211,7 +211,7 @@ class GT7Communication(Thread):
             time_delta = data_history[index].recvtime - data_history[index + 1].recvtime
             abs_rpm_delta = abs(data_history[index].rpm - data_history[index + 1].rpm)
             abs_speed_delta = abs(data_history[index].car_speed - data_history[index + 1].car_speed)
-            if time_delta <= 1.0 / 30 and (abs_rpm_delta > data_history[index + 1].rpm_rev_limiter * 0.1 or abs_speed_delta > data_history[index + 1].estimated_top_speed * 0.1):
+            if time_delta <= 1.0 / 30 and (abs_rpm_delta > data_history[index + 1].rpm_rev_limiter * 0.1):
                 log.info('Replay exit detected: time delta: %.4f s; rpm delta: %.2f (%.2f%%); speed delta: %.2f kph(%.2f%%)', time_delta, abs_rpm_delta, abs_rpm_delta * 100 / data_history[index + 1].rpm_rev_limiter, abs_speed_delta, abs_speed_delta * 100 / data_history[index + 1].estimated_top_speed)
                 for index_ in range (index + 1, len(data_history)):
                     data_history.pop()


### PR DESCRIPTION
An attempt to restore the capability to use the tool with the replay mode. Based on the discovery I posted [here](https://www.gtplanet.net/forum/threads/gt7-is-compatible-with-motion-rig.410728/post-13940716).

The only thing this fix does is determine what the player is doing based on the context of the telemetry stream, and force the `GTData.in_race` field to be `True` if we find that the player is in replay mode. The rest of the code base is untouched. Hopefully nothing is broken.

Some constants might need a bit of tweaking down the line, but it should work most of the time, with two caveats:

1. If you start the software while already in replay mode, it can't tell whether you are in the pre-race menu or a replay.
2. It determines that you're exiting a replay by detecting a large delta in engine RPM or car speed, so it might prematurely determine that you've exited the replay if you skip or rewind the replay.

In both cases, just quit and restart the replay.