### PR TITLE
chore: Update for Python 3.12 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ You will have to have a running Python installation. Look [here](https://wiki.py
 
   * Run the file `run.ps1` with a double click
 * If you are on MacOS run the file `run.command`
+* If you are on MacOS and using Homebrew to manage your Python3 installation, run the file `brew.command`
 * If you are on Linux run the file `run.sh`
 
 The commands `pip3` or `python3` may be different on your OS. Try `pip` or `python` instead.

--- a/brew.command
+++ b/brew.command
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script should be used on MacOS when Python is a managed environment;
+# i.e.: when Python is installed via Homebrew or similar package managers
+#
+# @author MBDesu
+
+cd "$(dirname "$0")"
+
+python3 -m venv ./venv
+source ./venv/bin/activate
+python3 -m pip install -r requirements.txt
+python3 helper/download_cars_csv.py
+python3 -m bokeh serve .

--- a/gt7dashboard/gt7communication.py
+++ b/gt7dashboard/gt7communication.py
@@ -11,7 +11,7 @@ from datetime import timedelta
 from threading import Thread
 from typing import List
 
-from salsa20 import Salsa20_xor
+from Crypto.Cipher import Salsa20
 
 from gt7dashboard.gt7helper import seconds_to_lap_time
 from gt7dashboard.gt7lap import Lap
@@ -448,7 +448,8 @@ def salsa20_dec(dat):
     iv = bytearray()
     iv.extend(iv2.to_bytes(4, 'little'))
     iv.extend(iv1.to_bytes(4, 'little'))
-    ddata = Salsa20_xor(dat, bytes(iv), key[0:32])
+    cipher = Salsa20.new(key[0:32], bytes(iv))
+    ddata = cipher.decrypt(dat)
     magic = int.from_bytes(ddata[0:4], byteorder='little')
     if magic != 0x47375330:
         return bytearray(b'')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bokeh~=3.2.0
 pycryptodome~=3.12.0
 tabulate~=0.8.10
-pandas~=2.0.3
+pandas~=2.2.3
 scipy~=1.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bokeh~=3.2.0
-salsa20~=0.3.0
+pycryptodome~=3.12.0
 tabulate~=0.8.10
 pandas~=2.0.3
-scipy~=1.10.0
+scipy~=1.15.1


### PR DESCRIPTION
This pull request removes the dependency on `salsa20` and replaces it with its successor, `Crypto.Cipher` from the `PyCryptodome` package. This resolves #26.

It also adds a setup script for users who use a package manager to manage their Python3 installation, like MacOS users who use Homebrew.